### PR TITLE
GPII-4410: Making links work without the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm install
 
 ### Build
 
-#### Including depdencies
+#### Including dependencies
 
 For testing the extension in the browser, you'll need to ensure that the 3rd party dependencies have been copied to the
 source directory. This is performed by the following grunt task:
@@ -103,7 +103,7 @@ In both cases the extension will intercept the URL, remove the identifier and pa
 existing tabs/windows open to the requested URL, the URL is handled as normal. If one already exists it will open to
 that existing tab instead. In the case of `refreshsametab.morphic.org`, it will also trigger the page to reload.
 
-For example, `http://opensametab.morphic.org/en.wikipedia.org/wiki/URL` will open `https://en.wikipedia.org/wiki/URL`.
+For example, `http://opensametab.morphic.org/redirect/https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FURL` will open `https://en.wikipedia.org/wiki/URL`.
 
 #### Caveats
 

--- a/src/background/openURLs.js
+++ b/src/background/openURLs.js
@@ -58,12 +58,16 @@ openURLs.handleRequest = details => {
     const destination = url.pathname.replace(/^\/(redirect\/)?(.*)/, (match, c1, c2) => decodeURIComponent(c2));
 
     let success;
+    // Validate the URL.
     try {
         const destinationUrl = new URL(destination);
-        openURLs.openTab(destinationUrl, refresh);
         success = true;
     } catch (e) {
         success = false;
+    }
+
+    if (success) {
+        openURLs.openTab(destinationUrl, refresh);
     }
 
     return {cancel: success};

--- a/src/background/openURLs.js
+++ b/src/background/openURLs.js
@@ -57,20 +57,18 @@ openURLs.handleRequest = details => {
     // URL will look like: "http://opensametab.morphic.org/redirect/https%3A%2F%2Fexample.com%2F"
     const destination = url.pathname.replace(/^\/(redirect\/)?(.*)/, (match, c1, c2) => decodeURIComponent(c2));
 
-    let success;
-    // Validate the URL.
+    let destinationUrl;
     try {
-        const destinationUrl = new URL(destination);
-        success = true;
+        destinationUrl = new URL(destination);
     } catch (e) {
-        success = false;
+        // ignored
     }
 
-    if (success) {
+    if (destinationUrl) {
         openURLs.openTab(destinationUrl, refresh);
     }
 
-    return {cancel: success};
+    return {cancel: !!destinationUrl};
 };
 
 openURLs.bindListener = () => {

--- a/tests/js/openURLsTests.js
+++ b/tests/js/openURLsTests.js
@@ -96,7 +96,7 @@
         blankTab: {
             id: 1
         },
-        url: "https://actual.org/url",
+        url: new URL("https://actual.org/url"),
         queryURL: "*://actual.org/url"
     };
 
@@ -134,7 +134,7 @@
                 jqUnit.assertTrue("Tab isn't highlighted", browser.tabs.highlight.notCalled);
                 jqUnit.assertTrue("Loading tab isnt' removed", browser.tabs.remove.notCalled);
                 jqUnit.assertTrue("Tab isn't reloaded", browser.tabs.reload.notCalled);
-                let isUpdatedCalled = browser.tabs.update.calledOnceWithExactly(loadingTab.id, {url: openTabTestsProps.url});
+                let isUpdatedCalled = browser.tabs.update.calledOnceWithExactly(loadingTab.id, {url: openTabTestsProps.url.href});
                 jqUnit.assertTrue("Loading tab is updated with correct URL", isUpdatedCalled);
             }
 
@@ -151,29 +151,29 @@
     const handlestRequestTestCases = [{
         name: "Open same tab",
         details: {
-            url: "https://opensametab.morphic.org/actual.org/url"
+            url: "https://opensametab.morphic.org/redirect/https%3A%2F%2Factual.org/url"
         },
         expected: {
             response: {cancel: true},
-            args: ["https://actual.org/url", false]
+            args: [new URL("https://actual.org/url"), false]
         }
     }, {
         name: "Refresh tab",
         details: {
-            url: "http://refreshsametab.morphic.org/actual.org/url"
+            url: "http://refreshsametab.morphic.org/redirect/http%3A%2F%2Factual.org/url"
         },
         expected: {
             response: {cancel: true},
-            args: ["http://actual.org/url", true]
+            args: [new URL("http://actual.org/url"), true]
         }
     }, {
         name: "Unfiltered URL",
         details: {
-            url: "http://morphic.org/actual.org/url"
+            url: "http://morphic.org/redirect/https%3A%2F%2Factual.org/url"
         },
         expected: {
             response: {cancel: true},
-            args: ["http://morphic.org/actual.org/url", false]
+            args: [new URL("http://morphic.org/redirect/https%3A%2F%2Factual.org/url"), false]
         }
     }];
 

--- a/tests/js/openURLsTests.js
+++ b/tests/js/openURLsTests.js
@@ -193,7 +193,7 @@
             let response = openURLs.handleRequest(testCase.details);
             jqUnit.assertDeepEq(`${testCase.name}: the response is returned correctly`, testCase.expected.response, response);
 
-            let isOpenTabCalledProperly = !testCase.expected.args || openTabStub.calledOnceWithExactly.apply(openTabStub, testCase.expected.args)
+            let isOpenTabCalledProperly = !testCase.expected.args || openTabStub.calledOnceWithExactly.apply(openTabStub, testCase.expected.args);
             jqUnit.assertTrue(`${testCase.name}: the openURLs.openTab method was called with the correct args`, isOpenTabCalledProperly);
 
             // clean up

--- a/tests/js/openURLsTests.js
+++ b/tests/js/openURLsTests.js
@@ -175,6 +175,15 @@
             response: {cancel: true},
             args: [new URL("http://morphic.org/redirect/https%3A%2F%2Factual.org/url"), false]
         }
+    }, {
+        name: "Bad URL",
+        details: {
+            url: "http://morphic.org/redirect/stupid"
+        },
+        expected: {
+            response: {cancel: false},
+            args: null
+        }
     }];
 
     jqUnit.test("test openURLs.handleRequest", () => {
@@ -184,7 +193,7 @@
             let response = openURLs.handleRequest(testCase.details);
             jqUnit.assertDeepEq(`${testCase.name}: the response is returned correctly`, testCase.expected.response, response);
 
-            let isOpenTabCalledProperly = openTabStub.calledOnceWithExactly.apply(openTabStub, testCase.expected.args);
+            let isOpenTabCalledProperly = !testCase.expected.args || openTabStub.calledOnceWithExactly.apply(openTabStub, testCase.expected.args)
             jqUnit.assertTrue(`${testCase.name}: the openURLs.openTab method was called with the correct args`, isOpenTabCalledProperly);
 
             // clean up


### PR DESCRIPTION
This makes the entire destination URL be specified. That way, a https link can be specified, without requiring the request url to be https.

Also, `/request` is at the start of the path to allow it to be passed easily to the shared listener on morphic, for when the extension isn't installed - so the url will always be a valid url which points to the destination.

Example: `http://opensametab.morphic.org/redirect/https%3A%2F%2Fexample.com`